### PR TITLE
fix: Replace wildcard import with explicit imports in VMIdManager.java

### DIFF
--- a/core/src/classpath/ext/gnu/classpath/jdwp/VMIdManager.java
+++ b/core/src/classpath/ext/gnu/classpath/jdwp/VMIdManager.java
@@ -43,7 +43,17 @@ package gnu.classpath.jdwp;
 
 import gnu.classpath.jdwp.exception.InvalidClassException;
 import gnu.classpath.jdwp.exception.InvalidObjectException;
-import gnu.classpath.jdwp.id.*;
+import gnu.classpath.jdwp.id.ArrayId;
+import gnu.classpath.jdwp.id.ArrayReferenceTypeId;
+import gnu.classpath.jdwp.id.ClassLoaderId;
+import gnu.classpath.jdwp.id.ClassObjectId;
+import gnu.classpath.jdwp.id.ClassReferenceTypeId;
+import gnu.classpath.jdwp.id.InterfaceReferenceTypeId;
+import gnu.classpath.jdwp.id.ObjectId;
+import gnu.classpath.jdwp.id.ReferenceTypeId;
+import gnu.classpath.jdwp.id.StringId;
+import gnu.classpath.jdwp.id.ThreadGroupId;
+import gnu.classpath.jdwp.id.ThreadId;
 
 import java.lang.ref.Reference;
 import java.lang.ref.ReferenceQueue;


### PR DESCRIPTION
## Summary

Replaced the wildcard import `import gnu.classpath.jdwp.id.*;` in `core/src/classpath/ext/gnu/classpath/jdwp/VMIdManager.java` with 11 explicit imports:
- ArrayId
- ArrayReferenceTypeId
- ClassLoaderId
- ClassObjectId
- ClassReferenceTypeId
- InterfaceReferenceTypeId
- ObjectId
- ReferenceTypeId
- StringId
- ThreadGroupId
- ThreadId

Build and tests pass successfully.