### PR TITLE
Remove 197 auto-generated TODO stub comments

### DIFF
--- a/cli/src/commands/org/jnode/command/common/ExprCommand.java
+++ b/cli/src/commands/org/jnode/command/common/ExprCommand.java
@@ -281,7 +281,6 @@ public class ExprCommand extends AbstractCommand {
     }
 
     private Object parseMatch(boolean evaluate) {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/core/src/classpath/ext/java/util/prefs/TransientPreferences.java
+++ b/core/src/classpath/ext/java/util/prefs/TransientPreferences.java
@@ -36,7 +36,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#childrenNamesSpi()
      */
     protected String[] childrenNamesSpi() throws BackingStoreException {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -44,7 +43,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#childSpi(java.lang.String)
      */
     protected AbstractPreferences childSpi(String name) {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -52,7 +50,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#flushSpi()
      */
     protected void flushSpi() throws BackingStoreException {
-        // TODO Auto-generated method stub
         
     }
 
@@ -60,7 +57,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#getSpi(java.lang.String)
      */
     protected String getSpi(String key) {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -68,7 +64,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#keysSpi()
      */
     protected String[] keysSpi() throws BackingStoreException {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -76,7 +71,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#putSpi(java.lang.String, java.lang.String)
      */
     protected void putSpi(String key, String value) {
-        // TODO Auto-generated method stub
         
     }
 
@@ -84,7 +78,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#removeNodeSpi()
      */
     protected void removeNodeSpi() throws BackingStoreException {
-        // TODO Auto-generated method stub
         
     }
 
@@ -92,7 +85,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#removeSpi(java.lang.String)
      */
     protected void removeSpi(String key) {
-        // TODO Auto-generated method stub
         
     }
 
@@ -100,7 +92,6 @@ public class TransientPreferences extends AbstractPreferences {
      * @see java.util.prefs.AbstractPreferences#syncSpi()
      */
     protected void syncSpi() throws BackingStoreException {
-        // TODO Auto-generated method stub
         
     }
     

--- a/core/src/core/org/jnode/assembler/x86/X86TextAssembler.java
+++ b/core/src/core/org/jnode/assembler/x86/X86TextAssembler.java
@@ -97,7 +97,6 @@ public class X86TextAssembler extends X86Assembler implements X86Operation {
         }
 
         public void addUnresolvedLink(int offset, int patchSize) {
-            // TODO Auto-generated method stub
 
         }
 

--- a/core/src/core/org/jnode/system/repository/plugins/PluginLoaderPlugin.java
+++ b/core/src/core/org/jnode/system/repository/plugins/PluginLoaderPlugin.java
@@ -79,7 +79,6 @@ public final class PluginLoaderPlugin extends RepositoryPlugin {
     @Override
     protected void providerAdded(SystemRepositoryProvider[] providers,
                                  SystemRepositoryProvider provider) {
-        // TODO Auto-generated method stub
         super.providerAdded(providers, provider);
     }
 
@@ -91,7 +90,6 @@ public final class PluginLoaderPlugin extends RepositoryPlugin {
     @Override
     protected void providerRemoved(SystemRepositoryProvider[] providers,
                                    SystemRepositoryProvider provider) {
-        // TODO Auto-generated method stub
         super.providerRemoved(providers, provider);
     }
 
@@ -146,7 +144,6 @@ public final class PluginLoaderPlugin extends RepositoryPlugin {
             for (SystemRepositoryProvider prov : pluginProviders) {
                 //todo empty ?
             }
-            // TODO Auto-generated method stub
             return null;
         }
     }

--- a/core/src/core/org/jnode/vm/compiler/ir/quad/PhiAssignQuad.java
+++ b/core/src/core/org/jnode/vm/compiler/ir/quad/PhiAssignQuad.java
@@ -62,7 +62,6 @@ public class PhiAssignQuad<T> extends AssignQuad<T> {
     }
 
     public int getLHSLiveAddress() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
@@ -93,7 +92,6 @@ public class PhiAssignQuad<T> extends AssignQuad<T> {
     }
 
     public void generateCode(CodeGenerator cg) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/core/src/core/org/jnode/vm/x86/VmX86Processor64.java
+++ b/core/src/core/org/jnode/vm/x86/VmX86Processor64.java
@@ -61,17 +61,14 @@ public final class VmX86Processor64 extends VmX86Processor {
 
     protected Address setupBootCode(ResourceManager rm, GDT gdt)
         throws ResourceNotFreeException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     protected void setupGDT(GDT gdt) {
-        // TODO Auto-generated method stub
 
     }
 
     protected void setupUserStack(byte[] userStack) {
-        // TODO Auto-generated method stub
 
     }
 }

--- a/core/src/core/org/jnode/vm/x86/compiler/l1a/FPCompilerSSE.java
+++ b/core/src/core/org/jnode/vm/x86/compiler/l1a/FPCompilerSSE.java
@@ -48,12 +48,10 @@ final class FPCompilerSSE extends FPCompiler {
     }
 
     void compare(boolean gt, int type, Label curInstrLabel) {
-        // TODO Auto-generated method stub
 
     }
 
     void convert(int fromType, int toType) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -62,7 +60,6 @@ final class FPCompilerSSE extends FPCompiler {
     }
 
     void fpaload(int type) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -71,7 +68,6 @@ final class FPCompilerSSE extends FPCompiler {
     }
 
     void neg(int type) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/core/src/core/org/jnode/vm/x86/compiler/l1b/FPCompilerSSE.java
+++ b/core/src/core/org/jnode/vm/x86/compiler/l1b/FPCompilerSSE.java
@@ -48,12 +48,10 @@ final class FPCompilerSSE extends FPCompiler {
     }
 
     void compare(boolean gt, int type, Label curInstrLabel) {
-        // TODO Auto-generated method stub
 
     }
 
     void convert(int fromType, int toType) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -62,7 +60,6 @@ final class FPCompilerSSE extends FPCompiler {
     }
 
     void fpaload(int type) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -71,7 +68,6 @@ final class FPCompilerSSE extends FPCompiler {
     }
 
     void neg(int type) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/core/src/emu/org/jnode/emu/plugin/model/DummyPluginDescriptor.java
+++ b/core/src/emu/org/jnode/emu/plugin/model/DummyPluginDescriptor.java
@@ -157,7 +157,6 @@ public class DummyPluginDescriptor implements PluginDescriptor {
     }
 
     public void removeListener(PluginDescriptorListener listener) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/core/src/mmtk-vm/org/jnode/vm/memmgr/mmtk/BaseMmtkHeapManager.java
+++ b/core/src/mmtk-vm/org/jnode/vm/memmgr/mmtk/BaseMmtkHeapManager.java
@@ -218,7 +218,6 @@ public abstract class BaseMmtkHeapManager extends VmHeapManager implements
     }
 
     public boolean isLowOnMemory() {
-        // TODO Auto-generated method stub
         return false;
     }
 

--- a/core/src/openjdk/vm/sun/font/NativeFontManager.java
+++ b/core/src/openjdk/vm/sun/font/NativeFontManager.java
@@ -82,49 +82,41 @@ class NativeFontManager {
 
                     @Override
                     Float getCharMetrics(char ch) {
-                        // TODO Auto-generated method stub
                         return new Float(10, 10);
                     }
 
                     @Override
                     float getCodePointAdvance(int cp) {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
 
                     @Override
                     StrikeMetrics getFontMetrics() {
-                        // TODO Auto-generated method stub
                         return new StrikeMetrics();
                     }
 
                     @Override
                     float getGlyphAdvance(int glyphCode) {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
 
                     @Override
                     void getGlyphImageBounds(int glyphcode, Float pt, Rectangle result) {
-                        // TODO Auto-generated method stub
                         result.setBounds((int) pt.getX(), (int) pt.getY(), 10, 10);
                     }
 
                     @Override
                     long getGlyphImagePtr(int glyphcode) {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
 
                     @Override
                     void getGlyphImagePtrs(int[] glyphCodes, long[] images, int len) {
-                        // TODO Auto-generated method stub
                         
                     }
 
                     @Override
                     Float getGlyphMetrics(int glyphcode) {
-                        // TODO Auto-generated method stub
                         return new Float(10, 10);
                     }
 
@@ -135,13 +127,11 @@ class NativeFontManager {
 
                     @Override
                     java.awt.geom.Rectangle2D.Float getGlyphOutlineBounds(int glyphCode) {
-                        // TODO Auto-generated method stub
                         return new java.awt.geom.Rectangle2D.Float(0, 0, 10, 10);
                     }
 
                     @Override
                     GeneralPath getGlyphVectorOutline(int[] glyphs, float x, float y) {
-                        // TODO Auto-generated method stub
                         GeneralPath path = getGlyphOutline(glyphs[0], x, y);
                         
                         for(int i = 1; i < glyphs.length; i++) {
@@ -153,7 +143,6 @@ class NativeFontManager {
 
                     @Override
                     public int getNumGlyphs() {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
                     
@@ -168,25 +157,21 @@ class NativeFontManager {
 
                     @Override
                     public void charsToGlyphs(int count, char[] unicodes, int[] glyphs) {
-                        // TODO Auto-generated method stub
                         
                     }
 
                     @Override
                     public void charsToGlyphs(int count, int[] unicodes, int[] glyphs) {
-                        // TODO Auto-generated method stub
                         
                     }
 
                     @Override
                     public boolean charsToGlyphsNS(int count, char[] unicodes, int[] glyphs) {
-                        // TODO Auto-generated method stub
                         return false;
                     }
 
                     @Override
                     public int getNumGlyphs() {
-                        // TODO Auto-generated method stub
                         return 0;
                     }
                     

--- a/core/src/test/org/jnode/test/InstanceofTest.java
+++ b/core/src/test/org/jnode/test/InstanceofTest.java
@@ -36,7 +36,6 @@ public class InstanceofTest {
                 }
             }
         }
-        // TODO Auto-generated method stub
 
     }
 

--- a/core/src/test/org/jnode/test/core/ProxyTest.java
+++ b/core/src/test/org/jnode/test/core/ProxyTest.java
@@ -58,7 +58,6 @@ public class ProxyTest {
      */
     public Object invoke(Object proxy, Method method, Object[] args)
         throws Throwable {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/core/src/test/org/jtestserver/tests/TestInputMessage.java
+++ b/core/src/test/org/jtestserver/tests/TestInputMessage.java
@@ -57,7 +57,6 @@ public class TestInputMessage {
         @Override
         public Client<Object, ? extends Protocol<Object>> createClient(InetAddress serverIp,
                 int serverPort) throws ProtocolException {
-            // TODO Auto-generated method stub
             return null;
         }
 
@@ -67,7 +66,6 @@ public class TestInputMessage {
         @Override
         public Server<Object, ? extends Protocol<Object>> createServer(int localPort)
             throws ProtocolException {
-            // TODO Auto-generated method stub
             return null;
         }
         

--- a/distr/src/apps/org/jnode/apps/jpartition/commands/FormatPartitionCommand.java
+++ b/distr/src/apps/org/jnode/apps/jpartition/commands/FormatPartitionCommand.java
@@ -51,7 +51,6 @@ public class FormatPartitionCommand extends BasePartitionCommand {
      */
     @Override
     protected final void doExecute(Context context) throws CommandException {
-        // TODO Auto-generated method stub
     }
 
     /**

--- a/distr/src/apps/org/jnode/apps/jpartition/commands/RemovePartitionCommand.java
+++ b/distr/src/apps/org/jnode/apps/jpartition/commands/RemovePartitionCommand.java
@@ -45,7 +45,6 @@ public class RemovePartitionCommand extends BasePartitionCommand {
      */
     @Override
     protected final void doExecute(Context context) throws CommandException {
-        // TODO Auto-generated method stub
     }
 
     /**

--- a/distr/src/apps/org/jnode/apps/telnetd/RemoteTextScreen.java
+++ b/distr/src/apps/org/jnode/apps/telnetd/RemoteTextScreen.java
@@ -84,7 +84,6 @@ public class RemoteTextScreen extends AbstractPcTextScreen {
      * {@inheritDoc}
      */
     public void copyTo(TextScreen dst, int offset, int length) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/fs/src/driver/org/jnode/driver/block/usb/storage/scsi/USBStorageSCSIDriver.java
+++ b/fs/src/driver/org/jnode/driver/block/usb/storage/scsi/USBStorageSCSIDriver.java
@@ -108,7 +108,6 @@ public class USBStorageSCSIDriver extends Driver
     }
 
     public PartitionTableEntry getPartitionTableEntry() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -126,22 +125,18 @@ public class USBStorageSCSIDriver extends Driver
     }
 
     public void write(long devOffset, ByteBuffer src) throws IOException {
-        // TODO Auto-generated method stub
 
     }
 
     public void flush() throws IOException {
-        // TODO Auto-generated method stub
 
     }
 
     public void requestCompleted(USBRequest request) {
-        // TODO Auto-generated method stub
 
     }
 
     public void requestFailed(USBRequest request) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -205,7 +200,6 @@ public class USBStorageSCSIDriver extends Driver
     }
 
     public void lock() throws IOException {
-        // TODO Auto-generated method stub
 
     }
 
@@ -214,7 +208,6 @@ public class USBStorageSCSIDriver extends Driver
     }
 
     public void eject() throws IOException {
-        // TODO Auto-generated method stub
 
     }
 

--- a/fs/src/driver/org/jnode/driver/bus/scsi/cdb/mmc/CDBRead10.java
+++ b/fs/src/driver/org/jnode/driver/bus/scsi/cdb/mmc/CDBRead10.java
@@ -45,7 +45,6 @@ public class CDBRead10 extends CDB {
 
     @Override
     public int getDataTransfertCount() {
-        // TODO Auto-generated method stub
         return 0;
     }
 

--- a/fs/src/driver/org/jnode/driver/bus/scsi/cdb/mmc/CDBReadCapacity.java
+++ b/fs/src/driver/org/jnode/driver/bus/scsi/cdb/mmc/CDBReadCapacity.java
@@ -39,7 +39,6 @@ public class CDBReadCapacity extends CDB {
 
     @Override
     public int getDataTransfertCount() {
-        // TODO Auto-generated method stub
         return 0;
     }
 

--- a/fs/src/driver/org/jnode/driver/bus/scsi/cdb/mmc/CDBStartStopUnit.java
+++ b/fs/src/driver/org/jnode/driver/bus/scsi/cdb/mmc/CDBStartStopUnit.java
@@ -94,7 +94,6 @@ public class CDBStartStopUnit extends CDB {
 
     @Override
     public int getDataTransfertCount() {
-        // TODO Auto-generated method stub
         return 0;
     }
 

--- a/fs/src/fs/org/jnode/fs/fat/FatFileSystem.java
+++ b/fs/src/fs/org/jnode/fs/fat/FatFileSystem.java
@@ -174,7 +174,6 @@ public class FatFileSystem extends AbstractFileSystem<FatRootEntry> {
      */
     protected FSFile createFile(FSEntry entry) throws IOException {
 
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -182,7 +181,6 @@ public class FatFileSystem extends AbstractFileSystem<FatRootEntry> {
      *
      */
     protected FSDirectory createDirectory(FSEntry entry) throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -190,7 +188,6 @@ public class FatFileSystem extends AbstractFileSystem<FatRootEntry> {
      *
      */
     protected FatRootEntry createRootEntry() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/fs/src/fs/org/jnode/fs/hfsplus/HfsPlusDirectory.java
+++ b/fs/src/fs/org/jnode/fs/hfsplus/HfsPlusDirectory.java
@@ -283,7 +283,6 @@ public class HfsPlusDirectory implements FSDirectory, FSDirectoryId {
     }
 
     private void writeEntries(final FSEntryTable entries) throws IOException {
-        // TODO Auto-generated method stub
     }
 
     /**

--- a/fs/src/fs/org/jnode/fs/hfsplus/HfsPlusFile.java
+++ b/fs/src/fs/org/jnode/fs/hfsplus/HfsPlusFile.java
@@ -77,7 +77,6 @@ public class HfsPlusFile implements FSFile, FSFileSlackSpace, FSFileStreams {
 
     @Override
     public void setLength(final long length) throws IOException {
-        // TODO Auto-generated method stub
     }
 
     @Override
@@ -95,7 +94,6 @@ public class HfsPlusFile implements FSFile, FSFileSlackSpace, FSFileStreams {
 
     @Override
     public void write(final long fileOffset, final ByteBuffer src) throws IOException {
-        // TODO Auto-generated method stub
 
     }
 

--- a/fs/src/fs/org/jnode/fs/iso9660/ISO9660FileSystem.java
+++ b/fs/src/fs/org/jnode/fs/iso9660/ISO9660FileSystem.java
@@ -85,7 +85,6 @@ public class ISO9660FileSystem extends AbstractFileSystem<ISO9660Entry> {
      *
      */
     protected FSFile createFile(FSEntry entry) throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -93,7 +92,6 @@ public class ISO9660FileSystem extends AbstractFileSystem<ISO9660Entry> {
      *
      */
     protected FSDirectory createDirectory(FSEntry entry) throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -101,7 +99,6 @@ public class ISO9660FileSystem extends AbstractFileSystem<ISO9660Entry> {
      *
      */
     protected ISO9660Entry createRootEntry() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/fs/src/fs/org/jnode/fs/jarfs/JarFSEntry.java
+++ b/fs/src/fs/org/jnode/fs/jarfs/JarFSEntry.java
@@ -67,7 +67,6 @@ public final class JarFSEntry implements FSEntry {
     }
 
     public FSDirectory getParent() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -92,17 +91,14 @@ public final class JarFSEntry implements FSEntry {
     }
 
     public FSFile getFile() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     public FSDirectory getDirectory() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     public FSAccessRights getAccessRights() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/fs/src/fs/org/jnode/fs/nfs/nfs2/NFS2AccessRights.java
+++ b/fs/src/fs/org/jnode/fs/nfs/nfs2/NFS2AccessRights.java
@@ -42,32 +42,26 @@ public class NFS2AccessRights extends NFS2Object implements FSAccessRights {
     }
 
     public boolean canRead() {
-        // TODO Auto-generated method stub
         return false;
     }
 
     public boolean canWrite() {
-        // TODO Auto-generated method stub
         return false;
     }
 
     public Principal getOwner() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
     public boolean setExecutable(boolean enable, boolean owneronly) {
-        // TODO Auto-generated method stub
         return false;
     }
 
     public boolean setReadable(boolean enable, boolean owneronly) {
-        // TODO Auto-generated method stub
         return false;
     }
 
     public boolean setWritable(boolean enable, boolean owneronly) {
-        // TODO Auto-generated method stub
         return false;
     }
 

--- a/fs/src/fs/org/jnode/fs/nfs/nfs2/NFS2Directory.java
+++ b/fs/src/fs/org/jnode/fs/nfs/nfs2/NFS2Directory.java
@@ -274,7 +274,6 @@ public class NFS2Directory extends NFS2Object implements FSDirectory {
     }
 
     public void flush() throws IOException {
-        // TODO Auto-generated method stub
     }
 
     public void remove(String name) throws IOException {

--- a/fs/src/fs/org/jnode/fs/ntfs/NTFSEntry.java
+++ b/fs/src/fs/org/jnode/fs/ntfs/NTFSEntry.java
@@ -156,7 +156,6 @@ public class NTFSEntry implements FSEntry, FSEntryCreated, FSEntryLastChanged, F
      * @see org.jnode.fs.FSEntry#getParent()
      */
     public FSDirectory getParent() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -222,7 +221,6 @@ public class NTFSEntry implements FSEntry, FSEntryCreated, FSEntryLastChanged, F
      * @see org.jnode.fs.FSEntry#setName(java.lang.String)
      */
     public void setName(String newName) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -278,7 +276,6 @@ public class NTFSEntry implements FSEntry, FSEntryCreated, FSEntryLastChanged, F
      * @see org.jnode.fs.FSEntry#getAccessRights()
      */
     public FSAccessRights getAccessRights() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -286,7 +283,6 @@ public class NTFSEntry implements FSEntry, FSEntryCreated, FSEntryLastChanged, F
      * @see org.jnode.fs.FSObject#isValid()
      */
     public boolean isValid() {
-        // TODO Auto-generated method stub
         return true;
     }
 

--- a/fs/src/fs/org/jnode/fs/ntfs/NTFSFile.java
+++ b/fs/src/fs/org/jnode/fs/ntfs/NTFSFile.java
@@ -95,7 +95,6 @@ public class NTFSFile implements FSFile, FSFileSlackSpace, FSFileStreams {
      * @see org.jnode.fs.FSFile#setLength(long)
      */
     public void setLength(long length) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -118,7 +117,6 @@ public class NTFSFile implements FSFile, FSFileSlackSpace, FSFileStreams {
      */
     // public void write(long fileOffset, byte[] src, int off, int len) {
     public void write(long fileOffset, ByteBuffer src) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/fs/src/fs/org/jnode/fs/ntfs/NTFSFileSystem.java
+++ b/fs/src/fs/org/jnode/fs/ntfs/NTFSFileSystem.java
@@ -126,14 +126,12 @@ public class NTFSFileSystem extends AbstractFileSystem<FSEntry> {
      * Flush all data.
      */
     public void flush() throws IOException {
-        // TODO Auto-generated method stub
     }
 
     /**
      *
      */
     protected FSFile createFile(FSEntry entry) throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -141,7 +139,6 @@ public class NTFSFileSystem extends AbstractFileSystem<FSEntry> {
      *
      */
     protected FSDirectory createDirectory(FSEntry entry) throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -149,7 +146,6 @@ public class NTFSFileSystem extends AbstractFileSystem<FSEntry> {
      *
      */
     protected NTFSEntry createRootEntry() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/fs/src/fs/org/jnode/fs/service/def/FileHandleImpl.java
+++ b/fs/src/fs/org/jnode/fs/service/def/FileHandleImpl.java
@@ -239,7 +239,6 @@ final class FileHandleImpl implements VMFileHandle {
     }
 
     public void unlock(long pos, long len) {
-        // TODO Auto-generated method stub
     }
 
     public int read() throws IOException {
@@ -260,12 +259,10 @@ final class FileHandleImpl implements VMFileHandle {
     }
 
     public boolean lock() {
-        // TODO Auto-generated method stub
         return true;
     }
 
     public MappedByteBuffer mapImpl(char mode, long position, int size) {
-        // TODO Auto-generated method stub
         return null;
     }
 }

--- a/fs/src/fs/org/jnode/fs/service/def/VirtualDirEntry.java
+++ b/fs/src/fs/org/jnode/fs/service/def/VirtualDirEntry.java
@@ -97,7 +97,6 @@ final class VirtualDirEntry implements FSEntry, FSDirectory, FSEntryCreated, FSE
      * @see org.jnode.fs.FSEntry#getAccessRights()
      */
     public FSAccessRights getAccessRights() throws IOException {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/fs/src/fs/org/jnode/fs/service/def/VirtualFS.java
+++ b/fs/src/fs/org/jnode/fs/service/def/VirtualFS.java
@@ -56,7 +56,6 @@ final class VirtualFS implements FileSystem<VirtualDirEntry> {
      * @see org.jnode.fs.FileSystem#close()
      */
     public void close() throws IOException {
-        // TODO Auto-generated method stub
     }
 
     /**

--- a/fs/src/test/org/jnode/test/fs/driver/context/IDEDiskPartitionDriverContext.java
+++ b/fs/src/test/org/jnode/test/fs/driver/context/IDEDiskPartitionDriverContext.java
@@ -32,7 +32,6 @@ public class IDEDiskPartitionDriverContext extends BlockDeviceAPIContext {
     public void init(TestConfig config, MockObjectTestCase testCase) throws Exception {
         super.init(config, testCase);
 
-        // TODO Auto-generated method stub
 
     }
 //  TODO: create context

--- a/gui/src/awt/org/jnode/awt/JNodeGraphics.java
+++ b/gui/src/awt/org/jnode/awt/JNodeGraphics.java
@@ -85,7 +85,6 @@ public class JNodeGraphics extends AbstractSurfaceGraphics {
      * @see java.awt.Graphics2D#getDeviceConfiguration()
      */
     public GraphicsConfiguration getDeviceConfiguration() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/gui/src/awt/org/jnode/awt/JNodeGraphicsConfiguration.java
+++ b/gui/src/awt/org/jnode/awt/JNodeGraphicsConfiguration.java
@@ -64,7 +64,6 @@ public class JNodeGraphicsConfiguration extends GraphicsConfiguration {
      * @see java.awt.GraphicsConfiguration#createCompatibleVolatileImage(int, int)
      */
     public VolatileImage createCompatibleVolatileImage(int w, int h) {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -96,7 +95,6 @@ public class JNodeGraphicsConfiguration extends GraphicsConfiguration {
      * @see java.awt.GraphicsConfiguration#getDefaultTransform()
      */
     public AffineTransform getDefaultTransform() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -111,7 +109,6 @@ public class JNodeGraphicsConfiguration extends GraphicsConfiguration {
      * @see java.awt.GraphicsConfiguration#getNormalizingTransform()
      */
     public AffineTransform getNormalizingTransform() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -128,7 +125,6 @@ public class JNodeGraphicsConfiguration extends GraphicsConfiguration {
 
     @Override
     public VolatileImage createCompatibleVolatileImage(int width, int height, int transparency) {
-        // TODO Auto-generated method stub
         return null;
     }
 }

--- a/gui/src/awt/org/jnode/awt/JNodeSurfaceGraphics2D.java
+++ b/gui/src/awt/org/jnode/awt/JNodeSurfaceGraphics2D.java
@@ -86,7 +86,6 @@ public class JNodeSurfaceGraphics2D extends SurfaceGraphics2D {
      * @see java.awt.Graphics2D#getDeviceConfiguration()
      */
     public GraphicsConfiguration getDeviceConfiguration() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/gui/src/awt/org/jnode/awt/JNodeToolkit.java
+++ b/gui/src/awt/org/jnode/awt/JNodeToolkit.java
@@ -151,7 +151,6 @@ public abstract class JNodeToolkit extends ClasspathToolkit implements FrameBuff
      */
     @Override
     public EmbeddedWindowPeer createEmbeddedWindow(EmbeddedWindow w) {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -581,7 +580,6 @@ public abstract class JNodeToolkit extends ClasspathToolkit implements FrameBuff
      *      java.util.Properties)
      */
     public PrintJob getPrintJob(Frame frame, String title, Properties props) {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -590,7 +588,6 @@ public abstract class JNodeToolkit extends ClasspathToolkit implements FrameBuff
      * @see java.awt.Toolkit#getScreenResolution()
      */
     public int getScreenResolution() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
@@ -988,7 +985,6 @@ public abstract class JNodeToolkit extends ClasspathToolkit implements FrameBuff
      */
     @SuppressWarnings("unchecked")
     public Map mapInputMethodHighlight(InputMethodHighlight highlight) {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -1026,7 +1022,6 @@ public abstract class JNodeToolkit extends ClasspathToolkit implements FrameBuff
      * @see java.awt.Toolkit#sync()
      */
     public void sync() {
-        // TODO Auto-generated method stub
 
     }
 

--- a/gui/src/awt/org/jnode/awt/font/truetype/TTFFontPeer.java
+++ b/gui/src/awt/org/jnode/awt/font/truetype/TTFFontPeer.java
@@ -128,7 +128,6 @@ public class TTFFontPeer extends JNodeFontPeer<TTFontProvider, TTFFont> {
 
     @Override
     public int getNumGlyphs(Font font) {
-        // TODO Auto-generated method stub
         return 0;
     }
 

--- a/gui/src/awt/org/jnode/awt/font/truetype/TTFPlugin.java
+++ b/gui/src/awt/org/jnode/awt/font/truetype/TTFPlugin.java
@@ -42,7 +42,6 @@ public class TTFPlugin extends Plugin {
      * @throws PluginException
      */
     protected void startPlugin() throws PluginException {
-        // TODO Auto-generated method stub
 
     }
 
@@ -52,7 +51,6 @@ public class TTFPlugin extends Plugin {
      * @throws PluginException
      */
     protected void stopPlugin() throws PluginException {
-        // TODO Auto-generated method stub
 
     }
 }

--- a/gui/src/awt/org/jnode/awt/image/BufferedImageGraphics2D.java
+++ b/gui/src/awt/org/jnode/awt/image/BufferedImageGraphics2D.java
@@ -64,7 +64,6 @@ public class BufferedImageGraphics2D extends SurfaceGraphics2D {
      * @see java.awt.Graphics2D#getDeviceConfiguration()
      */
     public GraphicsConfiguration getDeviceConfiguration() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/gui/src/awt/org/jnode/awt/image/ImageConsumerByte.java
+++ b/gui/src/awt/org/jnode/awt/image/ImageConsumerByte.java
@@ -69,7 +69,6 @@ public class ImageConsumerByte extends AbstractMemoryImageConsumer {
      * @see java.awt.image.ImageConsumer#setPixels(int, int, int, int, java.awt.image.ColorModel, byte[], int, int)
      */
     public void setPixels(int x, int y, int w, int h, ColorModel model, byte[] pixels, int offset, int scansize) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -85,7 +84,6 @@ public class ImageConsumerByte extends AbstractMemoryImageConsumer {
      * @see java.awt.image.ImageConsumer#setPixels(int, int, int, int, java.awt.image.ColorModel, int[], int, int)
      */
     public void setPixels(int x, int y, int w, int h, ColorModel model, int[] pixels, int offset, int scansize) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/gui/src/awt/org/jnode/awt/image/JNodeBufferedImageGraphics.java
+++ b/gui/src/awt/org/jnode/awt/image/JNodeBufferedImageGraphics.java
@@ -64,7 +64,6 @@ public class JNodeBufferedImageGraphics extends AbstractSurfaceGraphics {
      * @see java.awt.Graphics2D#getDeviceConfiguration()
      */
     public GraphicsConfiguration getDeviceConfiguration() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/gui/src/awt/org/jnode/awt/image/JNodeBufferedImageGraphics2D.java
+++ b/gui/src/awt/org/jnode/awt/image/JNodeBufferedImageGraphics2D.java
@@ -77,7 +77,6 @@ public class JNodeBufferedImageGraphics2D extends AbstractSurfaceGraphics2D {
      * @see java.awt.Graphics2D#getDeviceConfiguration()
      */
     public GraphicsConfiguration getDeviceConfiguration() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/gui/src/awt/org/jnode/awt/image/JNodeImage.java
+++ b/gui/src/awt/org/jnode/awt/image/JNodeImage.java
@@ -83,7 +83,6 @@ public class JNodeImage extends Image {
      * @see java.awt.Image#flush()
      */
     public void flush() {
-        // TODO Auto-generated method stub
 
     }
 

--- a/gui/src/awt/org/jnode/awt/image/JNodeImageGraphics.java
+++ b/gui/src/awt/org/jnode/awt/image/JNodeImageGraphics.java
@@ -58,7 +58,6 @@ public class JNodeImageGraphics extends AbstractGraphics {
      * @see java.awt.Graphics#copyArea(int, int, int, int, int, int)
      */
     public void copyArea(int x, int y, int width, int height, int dx, int dy) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -75,7 +74,6 @@ public class JNodeImageGraphics extends AbstractGraphics {
      * @see java.awt.Graphics2D#draw(java.awt.Shape)
      */
     public void draw(Shape shape) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -84,7 +82,6 @@ public class JNodeImageGraphics extends AbstractGraphics {
      * @see java.awt.Graphics2D#fill(java.awt.Shape)
      */
     public void fill(Shape shape) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -93,7 +90,6 @@ public class JNodeImageGraphics extends AbstractGraphics {
      * @see java.awt.Graphics2D#getDeviceConfiguration()
      */
     public GraphicsConfiguration getDeviceConfiguration() {
-        // TODO Auto-generated method stub
         return null;
     }
 

--- a/gui/src/awt/org/jnode/awt/swingpeers/DesktopFrame.java
+++ b/gui/src/awt/org/jnode/awt/swingpeers/DesktopFrame.java
@@ -55,7 +55,6 @@ public final class DesktopFrame extends JFrame implements JNodeAwtContext {
      */
     @Override
     public void repaint(long tm, int x, int y, int width, int height) {
-        // TODO Auto-generated method stub
         //log.info("repaint (" + tm + ", " + x + ", " + y + ", " + width + ", "
         //      + height);
         super.repaint(tm, x, y, width, height);

--- a/gui/src/awt/org/jnode/awt/swingpeers/DesktopFramePeer.java
+++ b/gui/src/awt/org/jnode/awt/swingpeers/DesktopFramePeer.java
@@ -87,7 +87,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.FramePeer#getState()
      */
     public int getState() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
@@ -95,7 +94,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.FramePeer#setIconImage(java.awt.Image)
      */
     public void setIconImage(Image image) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -116,7 +114,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.FramePeer#setResizable(boolean)
      */
     public void setResizable(boolean resizable) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -124,7 +121,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.FramePeer#setState(int)
      */
     public void setState(int state) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -132,7 +128,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.FramePeer#setTitle(java.lang.String)
      */
     public void setTitle(String title) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -140,7 +135,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.WindowPeer#toBack()
      */
     public void toBack() {
-        // TODO Auto-generated method stub
 
     }
 
@@ -148,7 +142,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.WindowPeer#toFront()
      */
     public void toFront() {
-        // TODO Auto-generated method stub
 
     }
 
@@ -156,7 +149,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ContainerPeer#beginLayout()
      */
     public void beginLayout() {
-        // TODO Auto-generated method stub
 
     }
 
@@ -164,7 +156,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ContainerPeer#beginValidate()
      */
     public void beginValidate() {
-        // TODO Auto-generated method stub
 
     }
 
@@ -172,7 +163,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ContainerPeer#endLayout()
      */
     public void endLayout() {
-        // TODO Auto-generated method stub
 
     }
 
@@ -180,7 +170,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ContainerPeer#endValidate()
      */
     public void endValidate() {
-        // TODO Auto-generated method stub
 
     }
 
@@ -205,7 +194,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ContainerPeer#isPaintPending()
      */
     public boolean isPaintPending() {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -213,7 +201,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#canDetermineObscurity()
      */
     public boolean canDetermineObscurity() {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -229,7 +216,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#coalescePaintEvent(java.awt.event.PaintEvent)
      */
     public void coalescePaintEvent(PaintEvent e) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -239,7 +225,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      */
     public void createBuffers(int x, BufferCapabilities capabilities)
         throws AWTException {
-        // TODO Auto-generated method stub
 
     }
 
@@ -288,7 +273,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#flip(java.awt.BufferCapabilities.FlipContents)
      */
     public void flip(FlipContents contents) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -296,7 +280,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#getBackBuffer()
      */
     public Image getBackBuffer() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -390,7 +373,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#handlesWheelScrolling()
      */
     public boolean handlesWheelScrolling() {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -412,7 +394,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#isObscured()
      */
     public boolean isObscured() {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -428,7 +409,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      */
     public void paint(Graphics graphics) {
         log.debug("Paint");
-        // TODO Auto-generated method stub
 
     }
 
@@ -452,7 +432,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#print(java.awt.Graphics)
      */
     public void print(Graphics graphics) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -491,7 +470,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#reshape(int, int, int, int)
      */
     public void reshape(int x, int y, int width, int height) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -499,7 +477,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#setBackground(java.awt.Color)
      */
     public void setBackground(Color color) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -507,7 +484,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#setBounds(int, int, int, int)
      */
     public void setBounds(int x, int y, int width, int height) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -515,7 +491,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#setCursor(java.awt.Cursor)
      */
     public void setCursor(Cursor cursor) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -523,7 +498,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#setEnabled(boolean)
      */
     public void setEnabled(boolean enabled) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -531,7 +505,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#setEventMask(long)
      */
     public void setEventMask(long mask) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -539,7 +512,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#setFont(java.awt.Font)
      */
     public void setFont(Font font) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -547,7 +519,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#setForeground(java.awt.Color)
      */
     public void setForeground(Color color) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -571,7 +542,6 @@ final class DesktopFramePeer extends JNodeGenericPeer<SwingToolkit, DesktopFrame
      * @see java.awt.peer.ComponentPeer#updateCursorImmediately()
      */
     public void updateCursorImmediately() {
-        // TODO Auto-generated method stub
 
     }
 

--- a/gui/src/awt/org/jnode/awt/swingpeers/SwingScrollPanePeer.java
+++ b/gui/src/awt/org/jnode/awt/swingpeers/SwingScrollPanePeer.java
@@ -49,7 +49,6 @@ final class SwingScrollPanePeer extends
      * @see java.awt.peer.ScrollPanePeer#childResized(int, int)
      */
     public void childResized(int width, int height) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -57,7 +56,6 @@ final class SwingScrollPanePeer extends
      * @see java.awt.peer.ScrollPanePeer#getHScrollbarHeight()
      */
     public int getHScrollbarHeight() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
@@ -65,7 +63,6 @@ final class SwingScrollPanePeer extends
      * @see java.awt.peer.ScrollPanePeer#getVScrollbarWidth()
      */
     public int getVScrollbarWidth() {
-        // TODO Auto-generated method stub
         return 0;
     }
 
@@ -73,7 +70,6 @@ final class SwingScrollPanePeer extends
      * @see java.awt.peer.ScrollPanePeer#setScrollPosition(int, int)
      */
     public void setScrollPosition(int h, int v) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -82,7 +78,6 @@ final class SwingScrollPanePeer extends
      *      int)
      */
     public void setUnitIncrement(Adjustable item, int inc) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -90,7 +85,6 @@ final class SwingScrollPanePeer extends
      * @see java.awt.peer.ScrollPanePeer#setValue(java.awt.Adjustable, int)
      */
     public void setValue(Adjustable item, int value) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/gui/src/awt/org/jnode/awt/swingpeers/SwingTextComponentPeer.java
+++ b/gui/src/awt/org/jnode/awt/swingpeers/SwingTextComponentPeer.java
@@ -46,7 +46,6 @@ abstract class SwingTextComponentPeer<awtT extends TextComponent, peerT extends 
      * @see java.awt.peer.TextComponentPeer#filterEvents(long)
      */
     public long filterEvents(long filter) {
-        // TODO Auto-generated method stub
         return 0;
     }
 
@@ -69,7 +68,6 @@ abstract class SwingTextComponentPeer<awtT extends TextComponent, peerT extends 
      * @see java.awt.peer.TextComponentPeer#getIndexAtPoint(int, int)
      */
     public int getIndexAtPoint(int x, int y) {
-        // TODO Auto-generated method stub
         return 0;
     }
 

--- a/gui/src/awt/org/jnode/awt/swingpeers/SwingTextFieldPeer.java
+++ b/gui/src/awt/org/jnode/awt/swingpeers/SwingTextFieldPeer.java
@@ -84,7 +84,6 @@ final class SwingTextFieldPeer extends
      * @see java.awt.peer.TextFieldPeer#setEchoCharacter(char)
      */
     public void setEchoCharacter(char echo_char) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/gui/src/awt/org/jnode/awt/util/AbstractGraphics.java
+++ b/gui/src/awt/org/jnode/awt/util/AbstractGraphics.java
@@ -112,7 +112,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      * @see java.awt.Graphics2D#addRenderingHints(java.util.Map)
      */
     public void addRenderingHints(Map<?, ?> hints) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -153,7 +152,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      */
     public boolean drawImage(Image image, AffineTransform xform,
                              ImageObserver obs) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -164,7 +162,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      *      java.awt.geom.AffineTransform)
      */
     public void drawRenderableImage(RenderableImage image, AffineTransform xform) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -175,7 +172,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      *      java.awt.geom.AffineTransform)
      */
     public void drawRenderedImage(RenderedImage image, AffineTransform xform) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -188,7 +184,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      */
     public void drawString(AttributedCharacterIterator iterator, float x,
                            float y) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -255,7 +250,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      * @see java.awt.Graphics2D#getRenderingHint(java.awt.RenderingHints.Key)
      */
     public Object getRenderingHint(Key hintKey) {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -264,7 +258,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      * @see java.awt.Graphics2D#getRenderingHints()
      */
     public RenderingHints getRenderingHints() {
-        // TODO Auto-generated method stub
         return null;
     }
 
@@ -292,7 +285,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      * @see java.awt.Graphics2D#hit(java.awt.Rectangle, java.awt.Shape, boolean)
      */
     public boolean hit(Rectangle rect, Shape text, boolean onStroke) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -357,7 +349,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      *      java.lang.Object)
      */
     public void setRenderingHint(Key hintKey, Object hintValue) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -366,7 +357,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      * @see java.awt.Graphics2D#setRenderingHints(java.util.Map)
      */
     public void setRenderingHints(Map<?, ?> hints) {
-        // TODO Auto-generated method stub
 
     }
 
@@ -532,7 +522,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      */
     public boolean drawImage(Image image, int x, int y, Color bgcolor,
                              ImageObserver observer) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -546,7 +535,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      *      java.awt.image.ImageObserver)
      */
     public boolean drawImage(Image image, int x, int y, ImageObserver observer) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -564,7 +552,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      */
     public boolean drawImage(Image image, int x, int y, int width, int height,
                              Color bgcolor, ImageObserver observer) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -581,7 +568,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      */
     public boolean drawImage(Image image, int x, int y, int width, int height,
                              ImageObserver observer) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -604,7 +590,6 @@ public abstract class AbstractGraphics extends Graphics2D {
     public boolean drawImage(Image image, int dx1, int dy1, int dx2, int dy2,
                              int sx1, int sy1, int sx2, int sy2, Color bgcolor,
                              ImageObserver observer) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -625,7 +610,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      */
     public boolean drawImage(Image image, int dx1, int dy1, int dx2, int dy2,
                              int sx1, int sy1, int sx2, int sy2, ImageObserver observer) {
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -890,7 +874,6 @@ public abstract class AbstractGraphics extends Graphics2D {
      *      float, float)
      */
     public void drawGlyphVector(GlyphVector g, float x, float y) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/gui/src/awt/org/jnode/awt/util/AbstractSurfaceGraphics.java
+++ b/gui/src/awt/org/jnode/awt/util/AbstractSurfaceGraphics.java
@@ -306,7 +306,6 @@ public abstract class AbstractSurfaceGraphics extends AbstractGraphics {
      */
     public final boolean drawImage(Image image, AffineTransform xform, ImageObserver obs) {
         log.debug("JnodeGraphics: drawImage");
-        // TODO Auto-generated method stub
         return false;
     }
 
@@ -326,7 +325,6 @@ public abstract class AbstractSurfaceGraphics extends AbstractGraphics {
      * @see java.awt.Graphics2D#drawRenderedImage(java.awt.image.RenderedImage, java.awt.geom.AffineTransform)
      */
     public final void drawRenderedImage(RenderedImage image, AffineTransform xform) {
-        // TODO Auto-generated method stub
 
     }
 

--- a/net/src/driver/org/jnode/driver/net/prism2/Prism2Core.java
+++ b/net/src/driver/org/jnode/driver/net/prism2/Prism2Core.java
@@ -488,7 +488,6 @@ final class Prism2Core extends WirelessDeviceCore implements Prism2Constants,
      * @see org.jnode.driver.net.wireless.spi.WirelessDeviceCore#setESSID(java.lang.String)
      */
     protected void setESSID(String essid) throws DriverException {
-        // TODO Auto-generated method stub
 
     }
 
@@ -496,7 +495,6 @@ final class Prism2Core extends WirelessDeviceCore implements Prism2Constants,
      * @see org.jnode.driver.net.wireless.spi.WirelessDeviceCore#startScan()
      */
     public void startScan() {
-        // TODO Auto-generated method stub
 
     }
 

--- a/net/src/net/org/jnode/net/ipv4/config/impl/NetDeviceMonitor.java
+++ b/net/src/net/org/jnode/net/ipv4/config/impl/NetDeviceMonitor.java
@@ -74,7 +74,6 @@ final class NetDeviceMonitor implements DeviceListener {
      * @see org.jnode.driver.DeviceListener#deviceStop(org.jnode.driver.Device)
      */
     public void deviceStop(Device device) {
-        // TODO Auto-generated method stub
 
     }
     

--- a/net/src/net/org/jnode/net/ipv4/tcp/TCPOutputStream.java
+++ b/net/src/net/org/jnode/net/ipv4/tcp/TCPOutputStream.java
@@ -63,7 +63,6 @@ public class TCPOutputStream extends OutputStream {
      * @see java.io.OutputStream#flush()
      */
     public void flush() throws IOException {
-        // TODO Auto-generated method stub
         super.flush();
     }
 

--- a/net/src/net/org/jnode/net/ipv4/tcp/TCPProtocol.java
+++ b/net/src/net/org/jnode/net/ipv4/tcp/TCPProtocol.java
@@ -208,7 +208,6 @@ public class TCPProtocol implements IPv4Protocol, IPv4Constants, TCPConstants {
      * @see org.jnode.net.ipv4.IPv4Protocol#receiveError(org.jnode.net.SocketBuffer)
      */
     public void receiveError(SocketBuffer skbuf) throws SocketException {
-        // TODO Auto-generated method stub
 
     }
 

--- a/net/src/net/org/jnode/net/ipv4/tcp/TCPSocketImpl.java
+++ b/net/src/net/org/jnode/net/ipv4/tcp/TCPSocketImpl.java
@@ -245,7 +245,6 @@ public class TCPSocketImpl extends SocketImpl {
      * @see java.net.SocketImpl#sendUrgentData(int)
      */
     protected void sendUrgentData(int data) throws IOException {
-        // TODO Auto-generated method stub
 
     }
 
@@ -253,7 +252,6 @@ public class TCPSocketImpl extends SocketImpl {
      * @see java.net.SocketOptions#setOption(int, java.lang.Object)
      */
     public void setOption(int option_id, Object val) throws SocketException {
-        // TODO Auto-generated method stub
 
     }
 

--- a/net/src/net/org/jnode/net/ipv4/udp/UDPDatagramSocketImpl.java
+++ b/net/src/net/org/jnode/net/ipv4/udp/UDPDatagramSocketImpl.java
@@ -70,7 +70,6 @@ public class UDPDatagramSocketImpl extends AbstractDatagramSocketImpl implements
      * @see java.net.DatagramSocketImpl#getTTL()
      */
     protected byte getTTL() throws IOException {
-        // TODO Auto-generated method stub
         return 0;
     }
 
@@ -115,7 +114,6 @@ public class UDPDatagramSocketImpl extends AbstractDatagramSocketImpl implements
      * @see java.net.DatagramSocketImpl#setTTL(byte)
      */
     protected void setTTL(byte ttl) throws IOException {
-        // TODO Auto-generated method stub
 
     }
 }

--- a/net/src/net/org/jnode/net/util/AbstractDatagramSocketImpl.java
+++ b/net/src/net/org/jnode/net/util/AbstractDatagramSocketImpl.java
@@ -198,7 +198,6 @@ public abstract class AbstractDatagramSocketImpl extends DatagramSocketImpl impl
      * @see java.net.DatagramSocketImpl#join(java.net.InetAddress)
      */
     protected void join(InetAddress inetaddr) throws IOException {
-        // TODO Auto-generated method stub
     }
 
     /**
@@ -206,14 +205,12 @@ public abstract class AbstractDatagramSocketImpl extends DatagramSocketImpl impl
      *      java.net.NetworkInterface)
      */
     protected void joinGroup(SocketAddress mcastaddr, NetworkInterface netIf) throws IOException {
-        // TODO Auto-generated method stub
     }
 
     /**
      * @see java.net.DatagramSocketImpl#leave(java.net.InetAddress)
      */
     protected void leave(InetAddress inetaddr) throws IOException {
-        // TODO Auto-generated method stub
     }
 
     /**
@@ -221,14 +218,12 @@ public abstract class AbstractDatagramSocketImpl extends DatagramSocketImpl impl
      *      java.net.NetworkInterface)
      */
     protected void leaveGroup(SocketAddress mcastaddr, NetworkInterface netIf) throws IOException {
-        // TODO Auto-generated method stub
     }
 
     /**
      * @see java.net.DatagramSocketImpl#peek(java.net.InetAddress)
      */
     protected int peek(InetAddress i) throws IOException {
-        // TODO Auto-generated method stub
         return 0;
     }
 

--- a/shell/src/shell/org/jnode/shell/bjorne/BjorneInterpreter.java
+++ b/shell/src/shell/org/jnode/shell/bjorne/BjorneInterpreter.java
@@ -187,7 +187,6 @@ public class BjorneInterpreter implements CommandInterpreter {
     
     @Override
     public synchronized boolean help(CommandShell shell, String partial, PrintWriter pw) throws ShellException {
-        // TODO Auto-generated method stub
         return false;
     }
 

--- a/shell/src/shell/org/jnode/shell/bjorne/ListCommandNode.java
+++ b/shell/src/shell/org/jnode/shell/bjorne/ListCommandNode.java
@@ -130,7 +130,6 @@ public class ListCommandNode extends CommandNode implements Completable {
     
     @Override
     public void complete(CompletionInfo completions, CommandShell shell) throws CompletionException {
-        // TODO Auto-generated method stub
 
     }
 }

--- a/shell/src/shell/org/jnode/shell/help/def/NewSyntaxHelp.java
+++ b/shell/src/shell/org/jnode/shell/help/def/NewSyntaxHelp.java
@@ -129,7 +129,6 @@ public class NewSyntaxHelp extends TextHelpBase implements EnhancedHelp {
 
     @Override
     public void details(PrintWriter pw) {
-        // TODO Auto-generated method stub
 
     }
 


### PR DESCRIPTION
## Summary
- Removed 197 `// TODO Auto-generated method stub` comments across 64 files
- Most were in GUI/swing peer implementations, shell, net, and fs packages
- Verified compilation with `sh build.sh assemble` - BUILD SUCCESSFUL
- No functional changes, only removed noise from the codebase