### PR TITLE
Remove empty comment lines (//) from source files

### DIFF
--- a/builder/src/builder/org/jnode/linker/Elf.java
+++ b/builder/src/builder/org/jnode/linker/Elf.java
@@ -20,8 +20,6 @@
  
 package org.jnode.linker;
 
-//
-//
 // typedef struct elf32_hdr{
 // EI_NIDENT = 16;
 // char e_ident[EI_NIDENT]; : e_ident[0...3] = '\x7f' "ELF" であること

--- a/builder/src/builder/org/jnode/linker/Section.java
+++ b/builder/src/builder/org/jnode/linker/Section.java
@@ -20,7 +20,6 @@
  
 package org.jnode.linker;
 
-//
 // ---- Section Header ---
 // typedef struct
 // {
@@ -35,7 +34,6 @@ package org.jnode.linker;
 // Elf32_Word sh_addralign; /* Section alignment */
 // Elf32_Word sh_entsize; /* Entry size if section holds table */
 // } Elf32_Shdr;
-//
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;

--- a/core/src/core/org/jnode/vm/compiler/ir/IRTest.java
+++ b/core/src/core/org/jnode/vm/compiler/ir/IRTest.java
@@ -179,7 +179,6 @@ public class IRTest {
 
 
 //        X86CodeGenerator x86cg = null;//new X86CodeGenerator(os, code.getLength());
-//
 //        generateCode(os, code, x86cg);
     }
 
@@ -271,11 +270,9 @@ public class IRTest {
 //        System.out.println(Arrays.asList(liveRanges));
 //        LinearScanAllocator lsa = new LinearScanAllocator(liveRanges);
 //        lsa.allocate();
-//
 //        x86cg.setArgumentVariables(irg.getVariables(), irg.getNoArgs());
 //        x86cg.setSpilledVariables(lsa.getSpilledVariables());
 //        x86cg.emitHeader();
-//
 //        n = quads.size();
 //        for (int i=0; i<n; i+=1) {
 //            Quad quad = (Quad) quads.get(i);

--- a/core/src/core/org/jnode/vm/compiler/ir/NativeTest.java
+++ b/core/src/core/org/jnode/vm/compiler/ir/NativeTest.java
@@ -174,22 +174,17 @@ public class NativeTest {
 //            BootableArrayList quads = irg.getQuadList();
 //            int n = quads.size();
 //            BootableHashMap liveVariables = new BootableHashMap();
-//
 //            for (int i=0; i<n; i+=1) {
 //                System.out.println(quads.get(i));
 //            }
-//
 //            for (int i=0; i<n; i+=1) {
 //                Quad quad = (Quad) quads.get(i);
 //                quad.doPass2(liveVariables);
 //            }
-//
 //            for (int i=0; i<n; i+=1) {
 //                System.out.println(quads.get(i));
 //            }
-//
 //            System.out.println(liveVariables);
-//
 //            Collection lv = liveVariables.values();
 //            n = lv.size();
 //            LiveRange[] liveRanges = new LiveRange[n];
@@ -204,14 +199,11 @@ public class NativeTest {
 //            LinearScanAllocator lsa = new LinearScanAllocator(liveRanges);
 //            lsa.allocate();
 //            System.out.println(Arrays.asList(liveRanges));
-//
 //            x86cg.setArgumentVariables(irg.getVariables(), irg.getNoArgs());
 //            System.out.println(Arrays.asList(liveRanges));
 //            x86cg.setSpilledVariables(lsa.getSpilledVariables());
 //            x86cg.emitHeader();
-//
 //            n = quads.size();
-//
 //            for (int i=0; i<n; i+=1) {
 //                Quad quad = (Quad) quads.get(i);
 //                if (!quad.isDeadCode()) {

--- a/core/src/core/org/jnode/vm/compiler/ir/PrimitiveTest.java
+++ b/core/src/core/org/jnode/vm/compiler/ir/PrimitiveTest.java
@@ -384,27 +384,21 @@ public class PrimitiveTest {
 //    public static long ladd(long a0, long a1) {
 //        return a0 + a1;
 //    }
-//
 //    public static long lsub(long a0, long a1) {
 //        return a0 - a1;
 //    }
-//
 //    public static long lmul(long a0, long a1) {
 //        return a0 * a1;
 //    }
-//
 //    public static long ldiv(long a0, long a1) {
 //        return a0 / a1;
 //    }
-//
 //    public static long land(long a0, long a1) {
 //        return a0 & a1;
 //    }
-//
 //    public static long lor(long a0, long a1) {
 //        return a0 | a1;
 //    }
-//
 //    public static long lxor(long a0, long a1) {
 //        return a0 ^ a1;
 //    }

--- a/core/src/core/org/jnode/vm/x86/compiler/l2/GenericX86CodeGenerator.java
+++ b/core/src/core/org/jnode/vm/x86/compiler/l2/GenericX86CodeGenerator.java
@@ -3834,7 +3834,6 @@ public class GenericX86CodeGenerator<T extends X86Register> extends CodeGenerato
 ////        helper.reset();
 ////        helper.setMethod(method);
 //        // this.startOffset = os.getLength();
-//
 //        this.startOffset = stackFrame.emitHeader();
     }
 
@@ -4420,12 +4419,10 @@ public class GenericX86CodeGenerator<T extends X86Register> extends CodeGenerato
             }
 
 //            // It is an interface, do it the hard way
-//
 //            // Load reference
 //            final RefItem ref = vstack.popRef();
 //            ref.load(eContext);
 //            final GPR refr = ref.getRegister();
-//
 //            // Allocate tmp registers
 //            final GPR classr = (GPR) L1AHelper.requestRegister(eContext,
 //                JvmType.REFERENCE, false);
@@ -4434,34 +4431,25 @@ public class GenericX86CodeGenerator<T extends X86Register> extends CodeGenerato
 //            final GPR tmpr = (GPR) L1AHelper.requestRegister(eContext,
 //                JvmType.REFERENCE, false);
 //            final Label curInstrLabel = currentLabel;
-//
 //            /* Objectref is already on the stack */
 //            writeResolveAndLoadClassToReg(classRef, classr);
 //            stackFrame.getHelper().writeClassInitialize(curInstrLabel, classr, tmpr, resolvedType);
-//
 //            final Label trueLabel = new Label(curInstrLabel + "io-true");
 //            final Label endLabel = new Label(curInstrLabel + "io-end");
-//
 //            /* Is instanceof? */
 //            instanceOf(refr, classr, tmpr, cntr, trueLabel, false, currentLabel);
-//
 //            final IntItem result = (IntItem) L1AHelper.requestWordRegister(eContext, JvmType.INT, false);
 //            final GPR resultr = result.getRegister();
-//
 //            /* Not instanceof */
 //            // TODO: use setcc instead of jumps
 //            os.writeXOR(resultr, resultr);
 //            os.writeJMP(endLabel);
-//
 //            os.setObjectRef(trueLabel);
 //            os.writeMOV_Const(resultr, 1);
-//
 //            // Push result
 //            os.setObjectRef(endLabel);
 //            ref.release(eContext);
-//
 //            vstack.push(result);
-//
 //            // Release
 //            pool.release(classr);
 //            pool.release(tmpr);

--- a/distr/src/test/org/jnode/apps/jpartition/utils/device/DeviceUtils.java
+++ b/distr/src/test/org/jnode/apps/jpartition/utils/device/DeviceUtils.java
@@ -95,9 +95,7 @@ public class DeviceUtils {
         
 //        if (!coreInitialized && !OsUtils.isJNode()) {
 //            // We are not running in JNode, emulate a JNode environment.
-//
 //            InitialNaming.setNameSpace(new BasicNameSpace());
-//
 //            // Build a plugin descriptor that is sufficient for the FileSystemPlugin to
 //            // configure file system types for testing.
 //            DummyPluginDescriptor desc = new DummyPluginDescriptor(true);
@@ -110,7 +108,6 @@ public class DeviceUtils {
 //                extension.addElement(element);
 //                ep.addExtension(extension);
 //            }
-//
 //            FileSystemService fss = new FileSystemPlugin(desc);
 //            try {
 //                InitialNaming.bind(FileSystemService.class, fss);

--- a/gui/src/awt/org/jnode/awt/font/spi/AbstractFontProvider.java
+++ b/gui/src/awt/org/jnode/awt/font/spi/AbstractFontProvider.java
@@ -248,7 +248,6 @@ public abstract class AbstractFontProvider<F extends Font, FD> implements FontPr
 //        }
 //        fontsLoaded = true;
 //    }
-//
 //    private final void loadFont(String resName) {
 //        try {
 //            final ClassLoader cl = Thread.currentThread().getContextClassLoader();

--- a/gui/src/awt/org/jnode/awt/font/truetype/TTFontProvider.java
+++ b/gui/src/awt/org/jnode/awt/font/truetype/TTFontProvider.java
@@ -84,7 +84,6 @@ public class TTFontProvider extends AbstractFontProvider<TTFFont, TTFFontData> {
     public TTFFontPeer createFontPeer(String name, Map<?, ?> attrs) {
         //TODO implement me
 //        TTFFontPeer peer = null;
-//
 //        List<BDFFontContainer> datas = getUserFontDatas();
 //        for (BDFFontContainer container : datas) {
 //            if (match(container, name, attrs)) {
@@ -93,14 +92,12 @@ public class TTFontProvider extends AbstractFontProvider<TTFFont, TTFFontData> {
 //                break;
 //            }
 //        }
-//        
 //        for (BDFFontContainer container : getContainers()) {
 //            if (match(container, name, attrs)) {
 //                peer = new TTFFontPeer(this, name, attrs);
 //                break;
 //            }
 //        }
-//        
 //        return peer;
         
         return new TTFFontPeer(this, name, attrs);

--- a/gui/src/test/org/jnode/test/gui/Imageutil.java
+++ b/gui/src/test/org/jnode/test/gui/Imageutil.java
@@ -29,7 +29,6 @@ public class Imageutil {
 //        Image img1 = Toolkit.getDefaultToolkit().getImage( file );
 //        javax.swing.ImageIcon ic = new javax.swing.ImageIcon(file);
 //        Image img1 = ic.getImage();
-//
 //        return img1;
 //    }
 }


### PR DESCRIPTION
## Summary
- Removed empty comment lines (`//`) from 10 source files (41 lines total)
- All files listed in the issue have been cleaned up
- Compilation verified with `sh build.sh assemble`

## Files Modified
- `builder/src/builder/org/jnode/linker/Elf.java` (2 occurrences)
- `builder/src/builder/org/jnode/linker/Section.java` (1 occurrence)
- `gui/src/awt/org/jnode/awt/font/truetype/TTFontProvider.java` (3 occurrences)
- `gui/src/awt/org/jnode/awt/font/spi/AbstractFontProvider.java` (1 occurrence)
- `gui/src/test/org/jnode/test/gui/Imageutil.java` (1 occurrence)
- `distr/src/test/org/jnode/apps/jpartition/utils/device/DeviceUtils.java` (3 occurrences)
- `core/src/core/org/jnode/vm/x86/compiler/l2/GenericX86CodeGenerator.java` (12 occurrences)
- `core/src/core/org/jnode/vm/compiler/ir/IRTest.java` (3 occurrences)
- `core/src/core/org/jnode/vm/compiler/ir/NativeTest.java` (8 occurrences)
- `core/src/core/org/jnode/vm/compiler/ir/PrimitiveTest.java` (6 occurrences)

Closes #11