### PR TITLE
Fixed 2 bugs in XMLElement.java

### DIFF
--- a/core/src/endorsed/nanoxml/org/jnode/nanoxml/XMLElement.java
+++ b/core/src/endorsed/nanoxml/org/jnode/nanoxml/XMLElement.java
@@ -1713,7 +1713,7 @@ public class XMLElement
             this.parseFromReader(new StringReader(string),
                                  /*startingLineNr*/ 1);
         } catch (IOException e) {
-            // Java exception handling suxx
+            throw new AssertionError(e);
         }
     }
 
@@ -1821,7 +1821,7 @@ public class XMLElement
         try {
             this.parseFromReader(new StringReader(string), startingLineNr);
         } catch (IOException e) {
-            // Java exception handling suxx
+            throw new AssertionError(e);
         }
     }
 
@@ -2301,6 +2301,7 @@ public class XMLElement
                 case '\t':
                 case '\n':
                     result.append(ch);
+                    break;
                 case '\r':
                     break;
                 default:


### PR DESCRIPTION
Fixed 2 critical bugs:

1. **Missing break statement** (line 2304): Added missing break after  in the 
  ο node/20.20.2

Use up/down arrow keys to select a version, return key to install, d to delete, q to quit     copying : node/20.20.2
   installed : v20.20.2 (with npm 10.8.2) case to prevent fallthrough to  case
2. **Swallowed IOException** (lines 1716, 1824): Replaced comment with  to fail fast if assumptions change

Closes #418