### PR TITLE
Fix ant fork=true NPE by parsing java command line

### DIFF
--- a/core/src/classpath/vm/java/lang/VMRuntime.java
+++ b/core/src/classpath/vm/java/lang/VMRuntime.java
@@ -223,6 +223,33 @@ final class VMRuntime
         String mainClassName = cmd[0];
         String[] cmdArgs = new String[cmd.length - 1];
         System.arraycopy(cmd, 1, cmdArgs, 0, cmdArgs.length);
+        
+        if ("java".equals(mainClassName)) {
+            String parsedClassName = null;
+            String[] parsedArgs = null;
+            int classpathEnd = 0;
+            
+            for (int i = 0; i < cmdArgs.length; i++) {
+                if ("-cp".equals(cmdArgs[i]) || "-classpath".equals(cmdArgs[i])) {
+                    if (i + 1 < cmdArgs.length) {
+                        i++;
+                    }
+                    classpathEnd = i + 1;
+                } else if (!cmdArgs[i].startsWith("-")) {
+                    parsedClassName = cmdArgs[i];
+                    int argsCount = cmdArgs.length - i - 1;
+                    parsedArgs = new String[argsCount];
+                    System.arraycopy(cmdArgs, i + 1, parsedArgs, 0, argsCount);
+                    break;
+                }
+            }
+            
+            if (parsedClassName != null) {
+                mainClassName = parsedClassName;
+                cmdArgs = parsedArgs != null ? parsedArgs : new String[0];
+            }
+        }
+        
         try {
             final Process p =
                 VmProcess.createProcess(mainClassName, cmdArgs, env);


### PR DESCRIPTION
## Summary

When ant uses `fork=true`, it constructs a command like `["java", "-cp", ".", "WH3"]`. `VMRuntime.exec()` was treating `cmd[0]` as the main class name, causing `Class.forName("java")` to fail with a NullPointerException.

## Changes

- core/src/classpath/vm/java/lang/VMRuntime.java:227-251 — Added parsing logic to detect when `cmd[0]` is "java" and extract the actual class name and arguments from the command line, skipping JVM flags like `-cp` and `-classpath`.

## Testing

- `sh build.sh assemble` → BUILD SUCCESSFUL
- The fix handles the exact command format ant uses: `["java", "-cp", ".", "WH3"]`
- Edge cases handled: no class name found, multiple JVM flags, both `-cp` and `-classpath` variants

Closes #1